### PR TITLE
Add slash command for remaining chat turns and reset

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -20,6 +20,9 @@ from bot import (
     save_history,
     get_user_model,
     save_user_model,
+    get_remaining_turns,
+    update_remaining_turns,
+    reset_remaining_turns,
     bot,
     process_request,
     process_queue,
@@ -27,6 +30,7 @@ from bot import (
     search,
     web,
     reset,
+    remaining_turns,
     help_command,
     should_respond_to_message,
     handle_user_message,
@@ -34,6 +38,7 @@ from bot import (
     generate_image,
     _generate_image_command,
     change_status,
+    daily_reset,
     on_ready
 )
 
@@ -108,6 +113,15 @@ class TestFullBot(unittest.TestCase):
     def test_reset_command(self):
         self.loop.run_until_complete(self.async_test_reset())
 
+    async def async_test_remaining_turns(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await remaining_turns.callback(interaction)
+        interaction.response.send_message.assert_called()
+
+    def test_remaining_turns_command(self):
+        self.loop.run_until_complete(self.async_test_remaining_turns())
+
     async def async_test_help_command(self):
         interaction = AsyncMock()
         await help_command(interaction)
@@ -153,3 +167,31 @@ class TestFullBot(unittest.TestCase):
                 model = get_user_model(1234)
                 self.assertEqual(model, "gpt-4o")
 
+    async def async_test_daily_reset(self):
+        await daily_reset()
+        # Verify that the reset_remaining_turns function was called
+        with patch("bot.reset_remaining_turns") as mock_reset:
+            await daily_reset()
+            mock_reset.assert_called_once()
+
+    def test_daily_reset_task(self):
+        self.loop.run_until_complete(self.async_test_daily_reset())
+
+    def test_get_remaining_turns(self):
+        with patch("bot.db.chat_turns.find_one", return_value={"remaining_turns": 5}):
+            remaining_turns = get_remaining_turns(1234, "gpt-4o")
+            self.assertEqual(remaining_turns, 5, "Should return the correct remaining turns from the database.")
+
+    def test_update_remaining_turns(self):
+        with patch("bot.db.chat_turns.update_one") as mock_update:
+            update_remaining_turns(1234, "gpt-4o", 10)
+            mock_update.assert_called_once_with(
+                {'user_id': 1234, 'model': "gpt-4o"},
+                {'$set': {'remaining_turns': 10}},
+                upsert=True
+            )
+
+    def test_reset_remaining_turns(self):
+        with patch("bot.db.chat_turns.update_many") as mock_update:
+            reset_remaining_turns()
+            mock_update.assert_called_once_with({}, {'$set': {'remaining_turns': 100}})


### PR DESCRIPTION
Add functionality to track and reset chat turns for each user and model, and implement a new slash command to check remaining chat turns.

- Add a new MongoDB collection `chat_turns` to track chat turns for each user and model.
- Implement functions to get, update, and reset remaining chat turns.
- Add a daily reset task to reset chat turns for all users and models.
- Add a new slash command `/remaining_turns` to check the remaining chat turns for each model.
- Update the help command to include the new `/remaining_turns` command.

- Add unit tests for the new MongoDB collection `chat_turns`.
- Add unit tests for the daily reset of chat turns.
- Add unit tests for the new slash command `/remaining_turns`.
- Add unit tests for the rate limits for each model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Coder-Vippro/ChatGPT-Discord-Bot/pull/7?shareId=0fec84a3-ac01-4c44-869a-bb42d719ced2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a `/remaining_turns` command to check available chat turns for each model
  - Implemented daily automatic reset of user chat turns

- **Improvements**
  - Introduced user-specific chat turn management
  - Added rate limiting for different AI models

- **Chores**
  - Enhanced bot functionality with turn tracking and reset mechanisms

These updates provide users with more transparency about their chat usage and help manage system resources effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->