### PR TITLE
Add slash command /user_stat to display user statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # ChatGPT Discord Bot
 
 ![Build and Push](https://github.com/coder-vippro/ChatGPT-Discord-Bot/actions/workflows/main.yml/badge.svg)
@@ -119,6 +118,7 @@ Once the bot is running, it connects to Discord using credentials from `.env`. C
 - **Scrape Web Content**: `/web url: "https://example.com"`
 - **Search Google**: `/search prompt: "latest news in Vietnam"`
 - **Normal chat**: `Ping the bot with a question or send a dms to the bot to start`
+- **User Statistics**: `/user_stat` - Get your current input token, output token, and model.
 
 ## CI/CD
 

--- a/bot.py
+++ b/bot.py
@@ -427,6 +427,27 @@ async def remaining_turns(interaction: discord.Interaction):
 
     await interaction.response.send_message("\n".join(remaining_turns_info), ephemeral=True)
 
+# Slash command for user statistics (/user_stat)
+@tree.command(name="user_stat", description="Get your current input token, output token, and model.")
+async def user_stat(interaction: discord.Interaction):
+    """Fetches and displays the current input token, output token, and model for the user."""
+    user_id = interaction.user.id
+    history = get_history(user_id)
+    model = get_user_model(user_id)
+
+    # Calculate input and output tokens
+    input_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'user')
+    output_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'assistant')
+
+    stat_message = (
+        f"**User Statistics:**\n"
+        f"Model: `{model}`\n"
+        f"Input Tokens: `{input_tokens}`\n"
+        f"Output Tokens: `{output_tokens}`\n"
+    )
+
+    await interaction.response.send_message(stat_message, ephemeral=True)
+
 # Slash command for help (/help)
 @tree.command(name="help", description="Display a list of available commands.")
 async def help_command(interaction: discord.Interaction):
@@ -439,6 +460,7 @@ async def help_command(interaction: discord.Interaction):
         "/generate `<prompt>` - Generate an image from a text prompt.\n"
         "/reset - Reset your conversation history.\n"
         "/remaining_turns - Check the remaining chat turns for each model.\n"
+        "/user_stat - Get your current input token, output token, and model.\n"
         "/help - Display this help message.\n"
         "**Các lệnh có sẵn:**\n"
         "/choose_model - Chọn mô hình AI để sử dụng cho phản hồi (gpt-4o, gpt-4o-mini, o1-preview, o1-mini).\n"
@@ -447,6 +469,7 @@ async def help_command(interaction: discord.Interaction):
         "/generate `<gợi ý>` - Tạo hình ảnh từ gợi ý văn bản.\n"
         "/reset - Đặt lại lịch sử trò chuyện của bạn.\n"
         "/remaining_turns - Kiểm tra số lượt trò chuyện còn lại cho mỗi mô hình.\n"
+        "/user_stat - Nhận thông tin về token đầu vào, token đầu ra và mô hình hiện tại của bạn.\n"
         "/help - Hiển thị tin nhắn trợ giúp này.\n"
     )
     await interaction.response.send_message(help_message, ephemeral=True)

--- a/bot.py
+++ b/bot.py
@@ -435,9 +435,18 @@ async def user_stat(interaction: discord.Interaction):
     history = get_history(user_id)
     model = get_user_model(user_id)
 
-    # Calculate input and output tokens
-    input_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'user')
-    output_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'assistant')
+    # Handle cases where user model is not found
+    if not model:
+        model = "gpt-4o-mini"
+
+    # Handle cases where user history is not found or blank
+    if not history or len(history) == 0:
+        input_tokens = 0
+        output_tokens = 0
+    else:
+        # Calculate input and output tokens
+        input_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'user')
+        output_tokens = sum(len(str(item['content'])) for item in history if item['role'] == 'assistant')
 
     stat_message = (
         f"**User Statistics:**\n"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -31,6 +31,7 @@ from bot import (
     web,
     reset,
     remaining_turns,
+    user_stat,
     help_command,
     should_respond_to_message,
     handle_user_message,
@@ -157,3 +158,107 @@ class TestFullBot(unittest.TestCase):
             with patch("bot.db.user_preferences.find_one", return_value=None):
                 model = get_user_model(1234)
                 self.assertEqual(model, "gpt-4o")
+
+    async def async_test_user_stat(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await user_stat.callback(interaction)
+        interaction.response.send_message.assert_called()
+
+    def test_user_stat_command(self):
+        self.loop.run_until_complete(self.async_test_user_stat())
+
+    def test_user_stat_default_model(self):
+        with patch("bot.get_user_model", return_value=None):
+            interaction = AsyncMock()
+            interaction.user.id = 1234
+            self.loop.run_until_complete(user_stat.callback(interaction))
+            interaction.response.send_message.assert_called_with(
+                "**User Statistics:**\nModel: `gpt-4o-mini`\nInput Tokens: `0`\nOutput Tokens: `0`\n", ephemeral=True
+            )
+
+    def test_user_stat_blank_history(self):
+        with patch("bot.get_history", return_value=[]):
+            interaction = AsyncMock()
+            interaction.user.id = 1234
+            self.loop.run_until_complete(user_stat.callback(interaction))
+            interaction.response.send_message.assert_called_with(
+                "**User Statistics:**\nModel: `gpt-4o`\nInput Tokens: `0`\nOutput Tokens: `0`\n", ephemeral=True
+            )
+
+    async def async_test_remaining_turns(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await remaining_turns.callback(interaction)
+        interaction.response.send_message.assert_called()
+
+    def test_remaining_turns_command(self):
+        self.loop.run_until_complete(self.async_test_remaining_turns())
+
+    async def async_test_generate_image(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await generate_image.callback(interaction, prompt="A beautiful sunset")
+        interaction.response.defer.assert_called()
+        interaction.followup.send.assert_called()
+
+    def test_generate_image_command(self):
+        self.loop.run_until_complete(self.async_test_generate_image())
+
+    async def async_test_choose_model(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await choose_model.callback(interaction)
+        interaction.response.send_message.assert_called()
+
+    def test_choose_model_command(self):
+        self.loop.run_until_complete(self.async_test_choose_model())
+
+    async def async_test_process_request(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await process_request(interaction, search.callback, "Python")
+        interaction.followup.send.assert_called()
+
+    def test_process_request_function(self):
+        self.loop.run_until_complete(self.async_test_process_request())
+
+    async def async_test_process_queue(self):
+        interaction = AsyncMock()
+        interaction.user.id = 1234
+        await process_queue(interaction)
+        interaction.followup.send.assert_called()
+
+    def test_process_queue_function(self):
+        self.loop.run_until_complete(self.async_test_process_queue())
+
+    async def async_test_handle_user_message(self):
+        message = AsyncMock()
+        message.author.id = 1234
+        await handle_user_message(message)
+        message.channel.send.assert_called()
+
+    def test_handle_user_message_function(self):
+        self.loop.run_until_complete(self.async_test_handle_user_message())
+
+    async def async_test_on_ready(self):
+        await on_ready()
+        self.assertTrue(change_status.is_running())
+        self.assertTrue(daily_reset.is_running())
+
+    def test_on_ready_event(self):
+        self.loop.run_until_complete(self.async_test_on_ready())
+
+    async def async_test_change_status(self):
+        await change_status()
+        self.assertTrue(bot.change_presence.called)
+
+    def test_change_status_task(self):
+        self.loop.run_until_complete(self.async_test_change_status())
+
+    async def async_test_daily_reset(self):
+        await daily_reset()
+        self.assertTrue(reset_remaining_turns.called)
+
+    def test_daily_reset_task(self):
+        self.loop.run_until_complete(self.async_test_daily_reset())


### PR DESCRIPTION
Add a new slash command `/user_stat` to fetch and display user statistics.

* **bot.py**
  - Add a new slash command `/user_stat` to fetch and display the current input token, output token, and model for the user.
  - Retrieve the user's history to calculate the input and output tokens.
  - Fetch the model from the database.
  - Update the `help_command` to include the new `/user_stat` command.

* **README.md**
  - Add documentation for the new `/user_stat` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Coder-Vippro/ChatGPT-Discord-Bot/pull/8?shareId=cd9b0b50-e894-416d-8801-30cf038b13fe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `/user_stat` command to retrieve user statistics.
	- Users can now check their input tokens, output tokens, and current AI model.
	- Updated help command to include information about the new user statistics feature.

- **Bug Fixes**
	- Enhanced error handling for scenarios with missing user data in the `/user_stat` command.

- **Tests**
	- Introduced new tests for the `/user_stat` command and other functionalities to ensure reliability and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->