### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -841,7 +841,9 @@ class ImageGenerator:
             }
             
             # For Discord CDN URLs, add bot authorization if available
-            if 'cdn.discordapp.com' in url or 'media.discordapp.net' in url:
+            from urllib.parse import urlparse
+            host = urlparse(url).hostname or ""
+            if host.lower() in ('cdn.discordapp.com', 'media.discordapp.net'):
                 try:
                     from src.config.config import DISCORD_TOKEN
                     if DISCORD_TOKEN:


### PR DESCRIPTION
Potential fix for [https://github.com/Coder-Vippro/ChatGPT-Discord-Bot/security/code-scanning/7](https://github.com/Coder-Vippro/ChatGPT-Discord-Bot/security/code-scanning/7)

The correct fix is to parse the URL and ensure the hostname portion matches the allowlist of image hosts (`cdn.discordapp.com`, etc.), rather than just checking for a substring presence anywhere in the URL. This should be performed using `urllib.parse.urlparse` to extract the `hostname` and compare it directly or using `.lower().endswith()` for subdomain/general matching.

Specifically, edit line 844 (and any similar logic for `media.discordapp.net`) in `src/utils/image_utils.py` within the `_download_image` method to parse the URL and check its `hostname` against the image hosts. This may require importing `urlparse` from `urllib.parse` if not already present.

No other changes outside these lines are required. Do not alter existing functionality, other than securing the host match.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord CDN URL validation to reduce false positives and enhance accuracy when processing image sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->